### PR TITLE
[20-feat] 사장님 가게 정보 등록 페이지 ui 완성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.9.0",
         "clsx": "^2.1.1",
+        "lucide-react": "^0.513.0",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-datepicker": "^8.4.0",
@@ -5211,6 +5212,15 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.513.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.513.0.tgz",
+      "integrity": "sha512-CJZKq2g8Y8yN4Aq002GahSXbG2JpFv9kXwyiOAMvUBv7pxeOFHUWKB0mO7MiY4ZVFCV4aNjv2BJFq/z3DgKPQg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "axios": "^1.9.0",
     "clsx": "^2.1.1",
+    "lucide-react": "^0.513.0",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-datepicker": "^8.4.0",

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -42,15 +42,15 @@ export default function Login() {
     if (!isEmailValid || !isPasswordValid) return;
 
     try {
-      const response = await axios.post(
-        'https://bootcamp-api.codeit.kr/api/15-8/the-julge/users/login',
-        { email, password },
-      );
+      const response = await axios.post('https://bootcamp-api.codeit.kr/api/15-8/the-julge/token', {
+        email,
+        password,
+      });
 
-      const token = response.data?.accessToken;
+      const token = response.data?.item?.token;
       if (token) {
         localStorage.setItem('accessToken', token);
-        router.push('/posts');
+        router.push('/');
       } else {
         alert('로그인에 실패했습니다.');
       }
@@ -65,7 +65,7 @@ export default function Login() {
 
   return (
     <LoginSignAuthFormWrapper>
-      <div className="text-center mb-8 cursor-pointer" onClick={() => router.push('/posts')}>
+      <div className="text-center mb-8 cursor-pointer" onClick={() => router.push('/')}>
         <Image
           src="/logo.png"
           alt="더줄게 로고"

--- a/src/app/owner/register-store/page.tsx
+++ b/src/app/owner/register-store/page.tsx
@@ -1,3 +1,207 @@
+'use client';
+
+import { ChevronDown } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation'; // Import useRouter
+
+const categories = ['한식', '중식', '일식', '양식', '분식'];
+
+const seoulcity = [
+  '서울시 종로구',
+  '서울시 중구',
+  '서울시 용산구',
+  '서울시 성동구',
+  '서울시 광진구',
+  '서울시 동대문구',
+  '서울시 중랑구',
+  '서울시 성북구',
+  '서울시 강북구',
+  '서울시 도봉구',
+  '서울시 노원구',
+  '서울시 은평구',
+  '서울시 서대문구',
+  '서울시 마포구',
+  '서울시 양천구',
+  '서울시 강서구',
+  '서울시 구로구',
+  '서울시 금천구',
+  '서울시 영등포구',
+  '서울시 동작구',
+  '서울시 관악구',
+  '서울시 서초구',
+  '서울시 강남구',
+  '서울시 송파구',
+  '서울시 강동구',
+];
+
 export default function Page() {
-  return <div className="">hellodfsdfsfdf</div>;
+  const router = useRouter(); // Initialize useRouter
+
+  const categoryRef = useRef<HTMLDivElement>(null);
+  const addressRef = useRef<HTMLDivElement>(null);
+
+  const [form, setForm] = useState({
+    name: '',
+    category: '',
+    district: '',
+    detailAddress: '',
+    basePay: '',
+    description: '',
+  });
+
+  const [categoryOpen, setCategoryOpen] = useState(false);
+  const [addressOpen, setAddressOpen] = useState(false);
+
+  const handleSelect = (key: keyof typeof form, value: string) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    if (key === 'category') setCategoryOpen(false);
+    if (key === 'district') setAddressOpen(false);
+  };
+
+  const handleClose = () => {
+    router.push('../owner');
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (categoryRef.current && !categoryRef.current.contains(event.target as Node)) {
+        setCategoryOpen(false);
+      }
+      if (addressRef.current && !addressRef.current.contains(event.target as Node)) {
+        setAddressOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div className="xl:px-[208px] mx-auto p-4">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-xl font-bold">가게 정보</h1>
+        <button className="text-2xl cursor-pointer" onClick={handleClose}>
+          ✕
+        </button>
+      </div>
+
+      {/* 가게 이름 & 분류 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+        <div>
+          <label className="text-sm block mb-1">가게 이름*</label>
+          <input
+            className="w-full border border-[color:var(--color-gray-20)] rounded px-3 py-2"
+            placeholder="입력"
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+          />
+        </div>
+
+        <div className="relative" ref={categoryRef}>
+          <label className="text-sm block mb-1">분류*</label>
+          <button
+            className="w-full border border-[color:var(--color-gray-20)] rounded px-3 py-2 text-left flex justify-between items-center"
+            onClick={() => setCategoryOpen((prev) => !prev)}
+          >
+            {form.category || '선택'}
+            <ChevronDown className="w-4 h-4" />
+          </button>
+          {categoryOpen && (
+            <ul className="absolute z-10 mt-1 w-full bg-white border border-[color:var(--color-gray-20)] rounded shadow max-h-48 overflow-y-auto">
+              {categories.map((cat) => (
+                <li
+                  key={cat}
+                  className="px-3 py-2 hover:bg-gray-100 cursor-pointer"
+                  onClick={() => handleSelect('category', cat)}
+                >
+                  {cat}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* 주소 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+        {/* 주소 드롭다운 */}
+        <div className="relative" ref={addressRef}>
+          <label className="text-sm block mb-1">주소*</label>
+          <button
+            className="w-full border border-[color:var(--color-gray-20)] rounded px-3 py-2 text-left flex justify-between items-center"
+            onClick={() => setAddressOpen((prev) => !prev)}
+          >
+            {form.district || '선택'}
+            <ChevronDown className="w-4 h-4" />
+          </button>
+          {addressOpen && (
+            <ul className="absolute z-10 mt-1 w-full bg-white border border-[color:var(--color-gray-20)] rounded shadow max-h-48 overflow-y-auto">
+              {seoulcity.map((addr) => (
+                <li
+                  key={addr}
+                  className="px-3 py-2 hover:bg-gray-100 cursor-pointer"
+                  onClick={() => handleSelect('district', addr)}
+                >
+                  {addr}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div>
+          <label className="text-sm block mb-1">상세 주소*</label>
+          <input
+            className="w-full border border-[color:var(--color-gray-20)] rounded px-3 py-2"
+            placeholder="입력"
+            value={form.detailAddress}
+            onChange={(e) => setForm({ ...form, detailAddress: e.target.value })}
+          />
+        </div>
+      </div>
+
+      {/* 기본 시급 */}
+      <div className="mb-4">
+        <label className="text-sm block mb-1">기본 시급*</label>
+        <div className="relative flex items-center w-1/2">
+          <input
+            className="w-full border border-[color:var(--color-gray-20)] rounded px-3 py-2"
+            placeholder="입력"
+            value={form.basePay}
+            onChange={(e) => setForm({ ...form, basePay: e.target.value })}
+          />
+          <span className="absolute right-3 text-gray-500">원</span>
+        </div>
+      </div>
+
+      {/* 이미지 업로드 (UI만) */}
+      <div className="mb-4">
+        <label className="text-sm block mb-1">가게 이미지</label>
+        <div className="w-1/2 h-40 border border-[color:var(--color-gray-20)] rounded flex items-center justify-center bg-gray-100 text-gray-2000 text-sm">
+          이미지 추가하기
+        </div>
+      </div>
+
+      {/* 설명 */}
+      <div className="mb-6">
+        <label className="text-sm block mb-1">가게 설명</label>
+        <textarea
+          className="w-full border border-[color:var(--color-gray-20)] rounded px-3 py-2"
+          placeholder="입력"
+          rows={4}
+          value={form.description}
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+        />
+      </div>
+
+      {/* 등록 버튼 */}
+      <div className="flex justify-center">
+        <button className="cursor-pointer hover:bg-orange-700 transition-colors duration-300 ease-in-out custom-button w-[108px] sm:w-[346px] h-[47px] bg-orange text-white py-2 rounded">
+          등록하기
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/src/app/sign/page.tsx
+++ b/src/app/sign/page.tsx
@@ -90,7 +90,7 @@ export default function Signup() {
 
   return (
     <LoginSignAuthFormWrapper>
-      <div className="mb-8 cursor-pointer" onClick={() => router.push('/posts')}>
+      <div className="mb-8 cursor-pointer" onClick={() => router.push('/')}>
         <Image
           src="/logo.png"
           alt="더줄게 로고"

--- a/src/lib/api/axios.ts
+++ b/src/lib/api/axios.ts
@@ -2,7 +2,6 @@ import axios from 'axios';
 
 const instance = axios.create({
   baseURL: 'https://bootcamp-api.codeit.kr/api/15-8/the-julge',
-  withCredentials: true,
 });
 
 export default instance;


### PR DESCRIPTION
## #️⃣연관된 이슈

> PR과 연관된 이슈 번호를 작성해주세요. ex) 

- close: #20 

## 🪄작업 내용

> 사장님 가게 정보 등록 페이지 ui 완성
> 회원가입, 로그인 기능 구현 완료
> 로그인 성공시 메인페이지로 리디액션
> 사장 가게 정보 등록시 ux를 위해 드롭다운 박스를 바깥 영역 클릭 시 닫히게 만듬
> x 버튼 클릭시 공고 등록하기 페이지로 리디액션


<img width="1470" alt="스크린샷 2025-06-10 오후 8 59 02" src="https://github.com/user-attachments/assets/301deb8f-b117-4383-a65d-845fb465c500" />

<img width="1470" alt="스크린샷 2025-06-10 오후 8 59 11" src="https://github.com/user-attachments/assets/b8358f43-e271-412c-8562-102c096b3d5a" />

-

## 💖리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-
