### PR TITLE
Feat: 사장님 공고 등록 구현

### DIFF
--- a/src/app/owner/owner-store-detail/MyJobPost.tsx
+++ b/src/app/owner/owner-store-detail/MyJobPost.tsx
@@ -47,21 +47,31 @@ export default function MyJobPost({
 
   return (
     <div className="p-4 max-w-[312px] max-h-[349px] border border-gray-20 bg-white rounded-2xl">
-      <div className="w-full max-w-[280px] max-h-[160px] border rounded-xl">
-        <img className="w-full max-w-[280px] max-h-[160px]" src={shopImageUrl} />
+      <div className="w-full max-w-[280px] h-40 max-h-[160px] border rounded-xl relative overflow-hidden">
+        <Image
+          src={shopImageUrl || ''}
+          alt={'가게 이미지'}
+          layout="fill"
+          objectFit="cover"
+          className="rounded-lg"
+        />
       </div>
       <div>
         <h3 className="text-black mt-4 font-bold text-lg">{shopName}</h3>
 
         <div className="flex gap-1.5 mt-2">
           <span className="flex items-center">
-            <Image
-              src="/clock-icon.png"
-              width={16}
-              height={16}
-              className="min-[375px]:w-5 min-[375px]:h-5"
-              alt="time"
-            />
+            {shopImageUrl ? (
+              <Image
+                src="/clock-icon.png"
+                width={16}
+                height={16}
+                className="min-[375px]:w-5 min-[375px]:h-5"
+                alt="time"
+              />
+            ) : (
+              <div>이미지 없음</div>
+            )}
           </span>
           <p className="text-gray-50 text-base max-[374px]:text-sm">{notice.startsAt}</p>
         </div>

--- a/src/app/owner/owner-store-detail/MyJobPost.tsx
+++ b/src/app/owner/owner-store-detail/MyJobPost.tsx
@@ -12,12 +12,12 @@ interface NoticeListItem {
   closed: boolean;
 }
 
-interface MyJobPostListProps {
+interface MyJobPostProps {
   notice: NoticeListItem;
   shopId: string;
 }
 
-export default function MyJobPostList({ notice, shopId }: MyJobPostListProps) {
+export default function MyJobPost({ notice, shopId }: MyJobPostProps) {
   const router = useRouter;
   const startsAtDate = new Date(notice.startsAt);
   const endTime = new Date(startsAtDate.getTime() + notice.workhour);

--- a/src/app/owner/owner-store-detail/MyJobPost.tsx
+++ b/src/app/owner/owner-store-detail/MyJobPost.tsx
@@ -15,54 +15,72 @@ interface NoticeListItem {
 interface MyJobPostProps {
   notice: NoticeListItem;
   shopId: string;
+  shopName: string;
+  shopAddress: string;
+  shopImageUrl?: string;
+  originalHourlyPay?: number;
 }
 
-export default function MyJobPost({ notice, shopId }: MyJobPostProps) {
-  const router = useRouter;
+export default function MyJobPost({
+  notice,
+  shopId,
+  shopName,
+  shopAddress,
+  shopImageUrl,
+  originalHourlyPay,
+}: MyJobPostProps) {
+  const router = useRouter();
   const startsAtDate = new Date(notice.startsAt);
   const endTime = new Date(startsAtDate.getTime() + notice.workhour);
 
-  return;
-  <div className="p-4 max-w-[312px] max-h-[349px]">
-    <div className="w-full">
-      <img />
-    </div>
-    <div>
-      <h3 className="text-black">가게명</h3>
-
-      <div className="flex gap-1.5 mt-3">
-        <span className="flex items-center">
-          <Image
-            src="/clock-icon.png"
-            width={16}
-            height={16}
-            className="min-[375px]:w-5 min-[375px]:h-5"
-            alt="time"
-          />
-        </span>
-        <p className="text-gray-50 text-base max-[374px]:text-sm">날짜 및 시간</p>
+  return (
+    <div className="p-4 max-w-[312px] max-h-[349px] border border-gray-20 bg-white rounded-2xl">
+      <div className="w-full max-w-[280px] max-h-[160px] border rounded-xl">
+        <img className="w-full max-w-[280px] max-h-[160px]" src={shopImageUrl} />
       </div>
-      <div className="flex gap-1.5 mt-3">
-        <span className="flex items-center">
-          <Image
-            src="/location-icon.png"
-            width={16}
-            height={16}
-            className="min-[375px]:w-5 min-[375px]:h-5"
-            alt="location"
-          />
-        </span>
-        <p className="text-gray-50 text-base max-[374px]:text-sm">위치</p>
-      </div>
+      <div>
+        <h3 className="text-black mt-4 font-bold text-lg">{shopName}</h3>
 
-      <div className="flex">
-        <h2>시급</h2>
-        {/* 있으면 보여주기 */}
-        <div>
-          <p>기존시급보다 ~ 50%</p>
-          <img />
+        <div className="flex gap-1.5 mt-2">
+          <span className="flex items-center">
+            <Image
+              src="/clock-icon.png"
+              width={16}
+              height={16}
+              className="min-[375px]:w-5 min-[375px]:h-5"
+              alt="time"
+            />
+          </span>
+          <p className="text-gray-50 text-base max-[374px]:text-sm">{notice.startsAt}</p>
+        </div>
+        <div className="flex gap-1.5 mt-2">
+          <span className="flex items-center">
+            <Image
+              src="/location-icon.png"
+              width={16}
+              height={16}
+              className="min-[375px]:w-5 min-[375px]:h-5"
+              alt="location"
+            />
+          </span>
+          <p className="text-gray-50 text-base max-[374px]:text-sm">{shopAddress}</p>
+        </div>
+
+        <div className="flex justify-between items-center mt-3">
+          <h2 className="text-xl font-bold">{notice.hourlyPay}원</h2>
+          {/* 있으면 보여주기 */}
+          <div className="rounded-4xl bg-orange px-3 py-2 flex gap-1">
+            <p className="text-white text-sm">기존 시급보다 50%</p>
+            <Image
+              src="/arrow-up-bold.png"
+              width={16}
+              height={16}
+              className="min-[375px]:w-5 min-[375px]:h-5"
+              alt="location"
+            />{' '}
+          </div>
         </div>
       </div>
     </div>
-  </div>;
+  );
 }

--- a/src/app/owner/owner-store-detail/MyJobPost.tsx
+++ b/src/app/owner/owner-store-detail/MyJobPost.tsx
@@ -31,7 +31,19 @@ export default function MyJobPost({
 }: MyJobPostProps) {
   const router = useRouter();
   const startsAtDate = new Date(notice.startsAt);
-  const endTime = new Date(startsAtDate.getTime() + notice.workhour);
+
+  // 시급 인상률 계산 로직
+  // originalHourlyPay가 유효하고, 0이 아니며, 현재 시급과 다를 때만 계산 및 표시
+  const showWageComparison =
+    originalHourlyPay !== undefined &&
+    originalHourlyPay !== 0 &&
+    notice.hourlyPay !== originalHourlyPay;
+
+  const increaseRate = showWageComparison
+    ? ((notice.hourlyPay - originalHourlyPay!) / originalHourlyPay!) * 100 // ! 단언문은 undefined가 아님을 확신할 때 사용
+    : 0; // 조건이 맞지 않으면 0%로 설정
+
+  const wageComparisonText = `기존 시급보다 ${increaseRate.toFixed(0)}%`;
 
   return (
     <div className="p-4 max-w-[312px] max-h-[349px] border border-gray-20 bg-white rounded-2xl">
@@ -69,16 +81,18 @@ export default function MyJobPost({
         <div className="flex justify-between items-center mt-3">
           <h2 className="text-xl font-bold">{notice.hourlyPay}원</h2>
           {/* 있으면 보여주기 */}
-          <div className="rounded-4xl bg-orange px-3 py-2 flex gap-1">
-            <p className="text-white text-sm">기존 시급보다 50%</p>
-            <Image
-              src="/arrow-up-bold.png"
-              width={16}
-              height={16}
-              className="min-[375px]:w-5 min-[375px]:h-5"
-              alt="location"
-            />{' '}
-          </div>
+          {showWageComparison && (
+            <div className="rounded-4xl bg-orange px-3 py-2 flex gap-1">
+              <p className="text-white text-sm">{wageComparisonText}</p>
+              <Image
+                src="/arrow-up-bold.png"
+                width={16}
+                height={16}
+                className="min-[375px]:w-5 min-[375px]:h-5"
+                alt="arrow-up"
+              />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/owner/owner-store-detail/MyJobPostList.tsx
+++ b/src/app/owner/owner-store-detail/MyJobPostList.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+
+interface NoticeListItem {
+  id: string;
+  hourlyPay: number;
+  startsAt: string;
+  workhour: number;
+  description: string;
+  closed: boolean;
+}
+
+interface MyJobPostListProps {
+  notice: NoticeListItem;
+  shopId: string;
+}
+
+export default function MyJobPostList({ notice, shopId }: MyJobPostListProps) {
+  const router = useRouter;
+  const startsAtDate = new Date(notice.startsAt);
+  const endTime = new Date(startsAtDate.getTime() + notice.workhour);
+
+  return;
+  <div className="p-4 max-w-[312px] max-h-[349px]">
+    <div className="w-full">
+      <img />
+    </div>
+    <div>
+      <h3 className="text-black">가게명</h3>
+
+      <div className="flex gap-1.5 mt-3">
+        <span className="flex items-center">
+          <Image
+            src="/clock-icon.png"
+            width={16}
+            height={16}
+            className="min-[375px]:w-5 min-[375px]:h-5"
+            alt="time"
+          />
+        </span>
+        <p className="text-gray-50 text-base max-[374px]:text-sm">날짜 및 시간</p>
+      </div>
+      <div className="flex gap-1.5 mt-3">
+        <span className="flex items-center">
+          <Image
+            src="/location-icon.png"
+            width={16}
+            height={16}
+            className="min-[375px]:w-5 min-[375px]:h-5"
+            alt="location"
+          />
+        </span>
+        <p className="text-gray-50 text-base max-[374px]:text-sm">위치</p>
+      </div>
+
+      <div className="flex">
+        <h2>시급</h2>
+        {/* 있으면 보여주기 */}
+        <div>
+          <p>기존시급보다 ~ 50%</p>
+          <img />
+        </div>
+      </div>
+    </div>
+  </div>;
+}

--- a/src/app/owner/owner-store-detail/MyStore.tsx
+++ b/src/app/owner/owner-store-detail/MyStore.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 
 export default function MyStore() {
+  const router = useRouter();
   const handleButton = () => {
-    return console.log('dd');
+    router.push('/owner/register-job');
   };
 
   return (
@@ -52,7 +54,7 @@ export default function MyStore() {
               className="cursor-pointer border px-1 w-full py-3.5 text-white text-base max-[374px]:text-sm font-bold bg-orange rounded-md"
               onClick={handleButton}
             >
-              공고 편집하기
+              공고 등록하기
             </button>
           </div>
         </div>

--- a/src/app/owner/owner-store-detail/RegisteredJob.tsx
+++ b/src/app/owner/owner-store-detail/RegisteredJob.tsx
@@ -1,26 +1,151 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { useMyStoreNoticeStore } from './store/MyStoreNoticesStore';
+import MyJobPost from './MyJobPost';
+import { useShopDetailStore } from './store/ShopDetailStore';
 
-export default function RegisteredJob() {
+interface NoticeListItem {
+  id: string;
+  hourlyPay: number;
+  startsAt: string;
+  workhour: number;
+  description: string;
+  closed: boolean;
+}
+
+interface LinkItem {
+  rel: string;
+  description: string;
+  method: string;
+  href: string;
+  body?: {
+    hourlyPay?: number;
+    startsAt?: string;
+    workhour?: number;
+    description?: string;
+    name?: string;
+    category?: string;
+    address1?: string;
+    address2?: string;
+    imageUrl?: string;
+    originalHourlyPay?: number;
+  };
+}
+
+interface GetNoticesResponse {
+  offset: number;
+  limit: number;
+  count: number;
+  hasNext: boolean;
+  items: NoticeListItem[];
+  links: LinkItem[];
+}
+
+// 가게 정보 상세 의 타입
+interface UserProfile {
+  id: string;
+  email: string;
+  type: 'employer' | 'employee';
+  name?: string;
+  phone?: string;
+  address?: string;
+  bio?: string;
+}
+
+interface ShopDetail {
+  id: string;
+  name: string;
+  category: string;
+  address1: string;
+  address2: string;
+  description: string;
+  imageUrl: string;
+  originalHourlyPay: number;
+  user: {
+    item: UserProfile;
+    href: string;
+  };
+}
+
+interface RegisteredJobProps {
+  shopId: string;
+}
+
+export default function RegisteredJob({ shopId }: RegisteredJobProps) {
   const router = useRouter();
+  const {
+    shopItem,
+    isLoading: isShopLoading,
+    error: shopError,
+    fetchShopDetail,
+  } = useShopDetailStore();
+
+  const { notices, totalCount, isLoading, error, hasMore, fetchNotices, clearNotices } =
+    useMyStoreNoticeStore();
+
+  useEffect(() => {
+    if (shopId) {
+      fetchShopDetail(shopId);
+      fetchNotices(shopId, false);
+    }
+    return () => {
+      clearNotices();
+    };
+  }, [shopId, fetchShopDetail, fetchNotices, clearNotices]);
+
   const handleButton = () => {
     router.push('/owner/register-job');
   };
+
+  if (isLoading && notices.length === 0) {
+    return <div>공고 목록 불러오는 중 ...</div>;
+  }
+
+  if (error) {
+    return <div>공고를 불러오지 못했습니다</div>;
+  }
+
+  if (notices.length === 0 && !isLoading && totalCount === 0) {
+    return (
+      <div className="bg-gray-5 py-15">
+        <div className="w-full max-w-[964px] px-8 max-[375px]:px-4 mx-auto">
+          <header className="mb-6">
+            <h1 className="text-2xl max-[374px]:text-lg font-bold">등록한 공고</h1>
+          </header>
+          <div className="w-full border border-gray-20 gap-6 py-15 rounded-2xl flex flex-col justify-center items-center">
+            <p className="">공고를 등록해 보세요.</p>
+            <button
+              className="cursor-pointer px-3 hover:bg-orange-700 transition-colors duration-300 ease-in-out custom-button w-[120px] sm:w-[346px] h-[47px] bg-orange text-white rounded-md"
+              onClick={handleButton}
+            >
+              공고 등록하기
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="bg-gray-5 py-15">
       <div className="w-full max-w-[964px] px-8 max-[375px]:px-4 mx-auto">
         <header className="mb-6">
-          <h1 className="text-2xl max-[374px]:text-lg font-bold">내 가게</h1>
+          <h1 className="text-2xl max-[374px]:text-lg font-bold">내가 등록한 공고</h1>
         </header>
-        <div className="w-full border border-gray-20 gap-6 py-15 rounded-2xl flex flex-col justify-center items-center">
-          <p className="">공고를 등록해 보세요.</p>
-          <button
-            className="cursor-pointer px-3 hover:bg-orange-700 transition-colors duration-300 ease-in-out custom-button w-[120px] sm:w-[346px] h-[47px] bg-orange text-white rounded-md"
-            onClick={handleButton}
-          >
-            공고 등록하기
-          </button>
+        <div className="grid grid-cols-1 md: grid-cols-2 lg: grid-cols-3 gap-4">
+          {notices.map((notice) => (
+            <MyJobPost
+              key={notice.id}
+              notice={notice}
+              shopId={shopId}
+              shopName={shopItem?.name || ''}
+              shopAddress={shopItem?.address1 || ''}
+              shopImageUrl={shopItem?.imageUrl || ''}
+              originalHourlyPay={shopItem?.originalHourlyPay}
+            />
+          ))}
         </div>
       </div>
     </div>

--- a/src/app/owner/owner-store-detail/page.tsx
+++ b/src/app/owner/owner-store-detail/page.tsx
@@ -1,11 +1,14 @@
+'use client';
+
 import MyStore from './MyStore';
 import RegisteredJob from './RegisteredJob';
 
 export default function OwnerStoreDetail() {
+  const Hardcooded_shop_id = 'cc5003b4-870f-4adb-bfe2-d906c33d04b7';
   return (
     <>
       <MyStore />
-      <RegisteredJob />
+      <RegisteredJob shopId={Hardcooded_shop_id} />
     </>
   );
 }

--- a/src/app/owner/owner-store-detail/store/MyStoreNoticesStore.ts
+++ b/src/app/owner/owner-store-detail/store/MyStoreNoticesStore.ts
@@ -1,0 +1,131 @@
+import { create } from 'zustand';
+import axiosInstance from '@/lib/api/axios';
+import axios from 'axios';
+
+interface NoticeListItem {
+  id: string;
+  hourlyPay: number;
+  startsAt: string;
+  workhour: number;
+  description: string;
+  closed: boolean;
+}
+
+interface LinkItem {
+  rel: string;
+  description: string;
+  method: string;
+  href: string;
+  body?: {
+    // `body`는 POST/PUT 요청에 대한 링크에만 존재하며, 그 내용도 명시
+    hourlyPay?: number;
+    startsAt?: string;
+    workhour?: number;
+    description?: string;
+    name?: string;
+    category?: string;
+    address1?: string;
+    address2?: string;
+    imageUrl?: string;
+    originalHourlyPay?: number;
+  };
+}
+
+interface GetNoticesResponse {
+  offset: number;
+  limit: number;
+  count: number; // 전체 개수
+  hasNext: boolean; // 다음 내용 존재 여부
+  items: NoticeListItem[];
+  links: LinkItem[];
+}
+
+interface MyStoreNoticesState {
+  notices: NoticeListItem[];
+  totalCount: number;
+  isLoading: boolean;
+  error: string | null;
+  currentPageOffset: number; // 현재 로드된 공고의 시작 위치 (offset)
+  hasMore: boolean; // 더 불러올 공고가 있는지 여부 (hasNext)
+
+  fetchNotices: (shopId: string, loadMore: boolean) => Promise<void>;
+  clearNotices: () => void;
+}
+
+export const useMyStoreNoticeStore = create<MyStoreNoticesState>((set, get) => ({
+  notices: [],
+  totalCount: 0,
+  isLoading: false,
+  error: null,
+  currentPageOffset: 0,
+  hasMore: true,
+
+  fetchNotices: async (shopId, loadMore) => {
+    const limit = 6;
+    const currentOffset = loadMore ? get().currentPageOffset : 0;
+    //중복호출 방지
+    if (
+      get().isLoading ||
+      (!loadMore && get().notices.length > 0) ||
+      (loadMore && !get().hasMore)
+    ) {
+      return;
+    }
+
+    set({ isLoading: true, error: null }); // 로딩 시작, 에러 초기화
+
+    try {
+      const response = await axiosInstance.get<GetNoticesResponse>(`/shops/${shopId}/notices`, {
+        params: {
+          offset: currentOffset,
+          limit: limit,
+        },
+      });
+      const newNotices = response.data.items;
+      set((state) => ({
+        notices: loadMore ? [...state.notices, ...newNotices] : newNotices,
+        totalCount: response.data.count,
+        currentPageOffset: currentOffset + newNotices.length,
+        hasMore: response.data.hasNext,
+        isLoading: false,
+      }));
+
+      console.log(
+        `[MyStoreNoticesStore] 공고 목록 불러오기 성공 (${shopId}, offset: ${currentOffset}):`,
+        response.data,
+      );
+    } catch (err) {
+      console.error(
+        `[MyStoreNoticesStore] 공고 목록 불러오기 실패 (${shopId}, offset: ${currentOffset}):`,
+        err,
+      );
+      let errorMessage = '공고 목록을 불러오기 실패';
+      if (axios.isAxiosError(err)) {
+        if (err.response?.status === 401) {
+          // 인증 오류
+          errorMessage = '인증 만료';
+        } else if (err.response?.data?.message) {
+          // 서버 메세지 우선
+          errorMessage = (err.response.data as { message?: string }).message || errorMessage;
+        } else if (err.request) {
+          //네트워크 오류
+          errorMessage = '네트워크 연결상태를 확인해보세요';
+        } else if (err instanceof Error) {
+          // 기타오류
+          errorMessage = err.message;
+        }
+      }
+      set({ error: errorMessage, isLoading: false, hasMore: false }); // 에러 시 더 이상 불러올 데이터 없다고 표시
+    }
+  },
+  clearNotices: () => {
+    set({
+      notices: [],
+      totalCount: 0,
+      isLoading: false,
+      error: null,
+      currentPageOffset: 0,
+      hasMore: true,
+    });
+  },
+}));

--- a/src/app/owner/owner-store-detail/store/MyStoreNoticesStore.ts
+++ b/src/app/owner/owner-store-detail/store/MyStoreNoticesStore.ts
@@ -16,19 +16,19 @@ interface LinkItem {
   description: string;
   method: string;
   href: string;
-  body?: {
-    // `body`는 POST/PUT 요청에 대한 링크에만 존재하며, 그 내용도 명시
-    hourlyPay?: number;
-    startsAt?: string;
-    workhour?: number;
-    description?: string;
-    name?: string;
-    category?: string;
-    address1?: string;
-    address2?: string;
-    imageUrl?: string;
-    originalHourlyPay?: number;
-  };
+  //   body?: {
+  //     // `body`는 POST/PUT 요청에 대한 링크에만 존재하며, 그 내용도 명시
+  //     hourlyPay?: number;
+  //     startsAt?: string;
+  //     workhour?: number;
+  //     description?: string;
+  //     name?: string;
+  //     category?: string;
+  //     address1?: string;
+  //     address2?: string;
+  //     imageUrl?: string;
+  //     originalHourlyPay?: number;
+  //   };
 }
 
 interface GetNoticesResponse {
@@ -36,7 +36,7 @@ interface GetNoticesResponse {
   limit: number;
   count: number; // 전체 개수
   hasNext: boolean; // 다음 내용 존재 여부
-  items: NoticeListItem[];
+  items: { item: NoticeListItem; links: LinkItem[] }[];
   links: LinkItem[];
 }
 
@@ -81,7 +81,7 @@ export const useMyStoreNoticeStore = create<MyStoreNoticesState>((set, get) => (
           limit: limit,
         },
       });
-      const newNotices = response.data.items;
+      const newNotices = response.data.items.map((itemWrapper) => itemWrapper.item);
       set((state) => ({
         notices: loadMore ? [...state.notices, ...newNotices] : newNotices,
         totalCount: response.data.count,

--- a/src/app/owner/owner-store-detail/store/ShopDetailStore.ts
+++ b/src/app/owner/owner-store-detail/store/ShopDetailStore.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand';
+import axiosInstance from '@/lib/api/axios';
+import axios from 'axios';
+
+interface UserProfile {
+  id: string;
+  email: string;
+  type: 'employer' | 'employee';
+  name?: string;
+  phone?: string;
+  address?: string;
+  bio?: string;
+}
+
+export interface ShopDetail {
+  id: string;
+  name: string;
+  category: string;
+  address1: string;
+  address2: string;
+  description: string;
+  imageUrl: string;
+  originalHourlyPay: number;
+  user: {
+    item: UserProfile;
+    href: string;
+  };
+}
+
+interface ShopDetailState {
+  shopItem: ShopDetail | null;
+  isLoading: boolean;
+  error: string | null;
+
+  fetchShopDetail: (shopId: string) => Promise<void>;
+
+  clearShopDetail: () => void;
+}
+
+export const useShopDetailStore = create<ShopDetailState>((set) => ({
+  shopItem: null,
+  isLoading: false,
+  error: null,
+
+  fetchShopDetail: async (shopId) => {
+    set({ isLoading: true, error: null, shopItem: null });
+    try {
+      const response = await axiosInstance.get<{ item: ShopDetail }>(`/shops/${shopId}`);
+
+      set({
+        shopItem: response.data.item,
+        isLoading: false,
+      });
+    } catch (err) {
+      console.error(`가게 상세 정보 불러오기 실패 (${shopId}):`, err);
+      let errorMessage = '가게 상세 정보 불러오기 실패';
+
+      if (axios.isAxiosError(err)) {
+        if (err.response?.status === 401) {
+          errorMessage = '인증실패';
+        } else if (err.request) {
+          errorMessage = '네트워크 오류';
+        }
+      } else {
+        //axios 오류 말고 다른 오류(런타임 오류 등)
+        errorMessage = (err as Error).message || '알 수 없는 오류';
+      }
+      set({ error: errorMessage, isLoading: false });
+    }
+  },
+  clearShopDetail: () => {
+    set({ shopItem: null, isLoading: false, error: null });
+  },
+}));


### PR DESCRIPTION
## #️⃣연관된 이슈

> PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

- close: #55 

## 🪄작업 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!


<details>
<summary>데스크탑</summary>
<img width="724" alt="Screenshot 2025-06-15 at 4 37 29 pm" src="https://github.com/user-attachments/assets/61006712-b1a5-4387-93bc-52b831afa382" />
</details>


- 사장님페이지 공고 등록할시 가게 상세 페이지에 공고 등록이 됩니다.
- 공고리스트 ui 구현하였습니다. 
- 가게 id를 넘겨받지 못해서 하드코딩으로 구현했습니다. 
- 우선 owner-store-detail (가게상세) 폴더에서 zustand store 로 2개의 파일을 만들었습니다. 
📦owner-store-detail
 ┣ 📂store
 ┃ ┣ 📜MyStoreNoticesStore.ts (공고 리스트 불러오는 상태관리)
 ┃ ┗ 📜ShopDetailStore.ts (가게 상세정보 불러오는 상태관리)
 ┣ 📜MyJobPost.tsx (공고 리스트의 공고 컴포넌트 1개)
 ┣ 📜MyStore.tsx (가게정보상세의 내 가게 컴포넌트)
 ┣ 📜RegisteredJob.tsx (가게정보상세의 공고 등록 컴포넌트)
 ┗ 📜page.tsx (가게정보상세 페이지)


- 무한 스크롤, 시간 수정, 등록된 공고(반응형) 추후 구현 예정입니다. 
- 추후 owner-page와 owner-store-detail 을 같은 페이지로 합칠 예정입니다.

## 💖리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

- 살려주세요 ㅋㅋㅋ
