### PR TITLE
feat: 마감공고, 지난공고 UI 처리 및 로컬스토리지 수정

### DIFF
--- a/src/app/owner/job-detail/ApplicantTable.tsx
+++ b/src/app/owner/job-detail/ApplicantTable.tsx
@@ -163,7 +163,8 @@ export default function ApplicantsTable({ shopId, noticeId }: ApplicantTableProp
             {applicants.length > 0 ? (
               applicants.map((applicant) => (
                 <tr key={applicant.id} className="border-b border-gray-20">
-                  <td className="px-3.5 py-4 w-[90px]">{applicant.name}</td>
+                  {/* 이름수 고정 */}
+                  <td className="px-3.5 py-4 w-[90px]">{applicant.name?.substring(0, 4)}</td>
                   <td className="px-3.5 py-4 w-[340px] hidden sm:table-cell">
                     <div // 스크롤 스타일을 위해서 div 추가
                       className="overflow-y-auto max-h-12"

--- a/src/app/owner/job-detail/StoreDetail.tsx
+++ b/src/app/owner/job-detail/StoreDetail.tsx
@@ -39,7 +39,7 @@ interface StoreDetailProps {
 }
 
 export default function StoreDetail({ item }: StoreDetailProps) {
-  const { hourlyPay, startsAt, workhour, description, shop } = item;
+  const { hourlyPay, startsAt, workhour, description, shop, closed } = item;
   const { name, category, address1, address2, imageUrl, originalHourlyPay } = shop.item;
   const fullAddress = `${address1} ${address2}`;
   const router = useRouter();
@@ -72,6 +72,11 @@ export default function StoreDetail({ item }: StoreDetailProps) {
 
   const displayTime = formatJobTime(startsAt, workhour);
 
+  const isExpired = closed;
+  const startsAtDate = new Date(startsAt);
+  const now = new Date();
+  const isPassed = startsAtDate.getTime() < now.getTime();
+
   return (
     <div className="w-full max-w-[964px] px-8 max-[375px]:px-4 mx-auto">
       <header className="mt-15 mb-6">
@@ -84,6 +89,13 @@ export default function StoreDetail({ item }: StoreDetailProps) {
       >
         <div className="w-full min-h-[308px] border-0 rounded-xl bg-amber-700 relative overflow-hidden">
           <Image src={imageUrl} alt="가게 이미지" layout="fill" objectFit="cover" />
+          {(isExpired || isPassed) && (
+            <div className="absolute inset-0 h-full w-full flex justify-center items-center bg-black opacity-70 z-10">
+              <span className="text-gray-20 font-bold text-3xl z-20">
+                {isExpired ? '마감 완료' : '지난 공고'}
+              </span>
+            </div>
+          )}
         </div>
         <div className="mt-4">
           <h3 className="text-base max-[374px]:text-sm text-orange font-bold">시급</h3>

--- a/src/app/owner/job-detail/[shopId]/[noticeId]/page.tsx
+++ b/src/app/owner/job-detail/[shopId]/[noticeId]/page.tsx
@@ -5,8 +5,9 @@ import ApplicantsTable from '../../ApplicantTable';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { useJobPostStore } from '../../stores/jobPostStore';
+import RouterGuard from '@/components/common/RouterGuard';
 
-export default function JobDetail() {
+const JobDetail = () => {
   const params = useParams();
   const shopId = params.shopId as string;
   const noticeId = params.noticeId as string;
@@ -46,4 +47,6 @@ export default function JobDetail() {
       <ApplicantsTable shopId={shopId} noticeId={noticeId} />
     </>
   );
-}
+};
+
+export default RouterGuard(JobDetail, ['employer']);

--- a/src/app/owner/owner-store-detail/MyJobPost.tsx
+++ b/src/app/owner/owner-store-detail/MyJobPost.tsx
@@ -21,7 +21,7 @@ interface MyJobPostProps {
   originalHourlyPay?: number;
 }
 
-const default_shop_image_url = '/logo.png';
+const default_shop_image_url = '/clock-closed-icon.png';
 
 export default function MyJobPost({
   notice,
@@ -43,12 +43,18 @@ export default function MyJobPost({
     : 0; // 조건이 맞지 않으면 0%로 설정
   const wageComparisonText = `기존 시급보다 ${increaseRate.toFixed(0)}%`;
 
+  const isExpired = notice.closed;
+  const startsAtDate = new Date(notice.startsAt);
+  const now = new Date();
+  const isPassed = startsAtDate.getTime() < now.getTime();
+
   const handleViewDetail = () => {
-    console.log(notice.closed);
-    if (!notice.closed) {
+    if (isExpired || isPassed) {
+      alert('마감이나 지난 공고입니다.');
+      //아예 못가게 하기 로 해도 됨
       router.push(`/owner/job-detail/${shopId}/${notice.id}`);
     } else {
-      alert('마감된 공고입니다.');
+      router.push(`/owner/job-detail/${shopId}/${notice.id}`);
     }
   };
 
@@ -68,10 +74,14 @@ export default function MyJobPost({
 
   return (
     <div
-      className={`p-4 max-w-[312px] max-h-[349px] border border-gray-20 bg-white rounded-2xl ${notice.closed ? 'cursor-not-allowed' : 'cursor-pointer'} `}
+      className={`p-4 max-w-[312px] max-h-[349px] border border-gray-20 bg-white rounded-2xl cursor-pointer `}
       onClick={handleViewDetail}
     >
-      <div className="w-full max-w-[280px] h-40 max-h-[160px] border rounded-xl relative overflow-hidden">
+      <div
+        className={`w-full max-w-[280px] h-40 max-h-[160px] border border-gray-30 rounded-xl relative overflow-hidden
+                  ${isExpired ? '' : 'cursor-pointer hover:shadow-md'}
+      `}
+      >
         <Image
           src={shopImageUrl || default_shop_image_url}
           alt={'가게 이미지'}
@@ -79,40 +89,65 @@ export default function MyJobPost({
           objectFit="cover"
           className="rounded-lg"
         />
+        {(isExpired || isPassed) && (
+          <div className="absolute inset-0 h-full w-full flex justify-center items-center bg-black opacity-70 z-10">
+            <span className="text-gray-20 font-bold text-3xl z-20">
+              {isExpired ? '마감 완료' : '지난 공고'}
+            </span>
+          </div>
+        )}
       </div>
       <div>
-        <h3 className="text-black mt-4 font-bold text-lg">{shopName}</h3>
+        <h3
+          className={`${isExpired || isPassed ? 'text-gray-20' : 'text-black'} mt-4 font-bold text-lg`}
+        >
+          {shopName}
+        </h3>
 
         <div className="flex gap-1 mt-2">
           <span className="flex items-center">
             <Image
-              src="/clock-icon.png"
+              src={isExpired || isPassed ? '/clock-closed-icon.png' : `/clock-icon.png`}
               width={16}
               height={16}
               className="min-[375px]:w-5 min-[375px]:h-5"
               alt="time"
             />
           </span>
-          <p className="text-gray-50 text-base max-[374px]:text-sm">{displayTime}</p>
+          <p
+            className={`${isExpired || isPassed ? 'text-gray-20' : 'text-gray-50'} text-base max-[374px]:text-sm`}
+          >
+            {displayTime}
+          </p>
         </div>
         <div className="flex gap-1 mt-2">
           <span className="flex items-center">
             <Image
-              src="/location-icon.png"
+              src={isExpired || isPassed ? '/location-closed-icon.png' : `/location-icon.png`}
               width={16}
               height={16}
               className="min-[375px]:w-5 min-[375px]:h-5"
               alt="location"
             />
           </span>
-          <p className="text-gray-50 text-base max-[374px]:text-sm">{shopAddress}</p>
+          <p
+            className={`${isExpired || isPassed ? 'text-gray-20' : 'text-gray-50'} text-base max-[374px]:text-sm`}
+          >
+            {shopAddress}
+          </p>
         </div>
 
         <div className="flex justify-between items-center mt-3">
-          <h2 className="text-xl font-bold">{notice.hourlyPay.toLocaleString('ko-KR')}원</h2>
+          <h2
+            className={`${isExpired || isPassed ? 'text-gray-20' : 'text-base'} text-xl font-bold`}
+          >
+            {notice.hourlyPay.toLocaleString('ko-KR')}원
+          </h2>
           {/* 있으면 보여주기 */}
           {showWageComparison && (
-            <div className="rounded-4xl bg-orange px-3 py-2 flex gap-1">
+            <div
+              className={`rounded-4xl px-3 py-2 flex gap-1 ${isExpired || isPassed ? 'bg-gray-10' : ' bg-orange'}`}
+            >
               <p className="text-white text-sm">{wageComparisonText}</p>
               <Image
                 src="/arrow-up-bold.png"

--- a/src/app/owner/owner-store-detail/MyStore.tsx
+++ b/src/app/owner/owner-store-detail/MyStore.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
+import { json } from 'stream/consumers';
 
 interface ShopData {
   name: string;
@@ -17,10 +18,27 @@ interface ShopData {
 export default function MyStore() {
   const [shop, setShop] = useState<ShopData | null>(null);
 
+  // (추후 로직 변경) 로그아웃하면서 로컬스토리지가 사라질 경우 유저의 id를 반영해서 shop정보 가져오기
+  // useEffect(() => {
+  //   const storedShop = localStorage.getItem('registeredShop');
+  //   const shopFromAuthData = localStorage.getItem('auth-data');
+  //   if (storedShop) {
+  //     setShop(JSON.parse(storedShop));
+  //   } else {
+  //     const authData = JSON.parse(shopFromAuthData);
+  //     const shopDetails = authData?.state?.userData?.item?.user?.item?.shop?.item;
+  //     setShop(shopDetails);
+  //   }
+  // }, []);
+
   useEffect(() => {
-    const storedShop = localStorage.getItem('registeredShop');
-    if (storedShop) {
-      setShop(JSON.parse(storedShop));
+    const shopFromAuthData = localStorage.getItem('auth-data');
+    if (shopFromAuthData) {
+      const authData = JSON.parse(shopFromAuthData);
+      const shopDetails = authData?.state?.userData?.item?.user?.item?.shop?.item;
+      setShop(shopDetails);
+    } else {
+      console.error();
     }
   }, []);
 
@@ -61,9 +79,15 @@ export default function MyStore() {
         className="w-full border border-gray-20 grid grid-cols-1 gap-8 p-6 rounded-2xl bg-red-10
                     md:grid-cols-[1fr_minmax(0,346px)]"
       >
-        <div className="w-full border-0 rounded-xl bg-gray-200 flex items-center justify-center overflow-hidden">
+        <div className="w-full border-0 rounded-xl bg-gray-200 flex items-center justify-center overflow-hidden relative">
           {shop.imageUrl ? (
-            <img src={shop.imageUrl} alt={shop.name} className="w-full h-full object-cover" />
+            <Image
+              src={shop.imageUrl}
+              alt={shop.name}
+              layout="fill"
+              objectFit="cover"
+              className="w-full h-full object-cover"
+            />
           ) : (
             <span className="text-gray-500">이미지 없음</span>
           )}

--- a/src/app/owner/owner-store-detail/RegisteredJob.tsx
+++ b/src/app/owner/owner-store-detail/RegisteredJob.tsx
@@ -81,10 +81,37 @@ export default function RegisteredJob() {
   const [shopId, setShopId] = useState<string>(''); //shopId 저장
 
   useEffect(() => {
-    const storeedShop = localStorage.getItem('registeredShop');
-    if (storeedShop) {
-      const paredShop: ShopDetail = JSON.parse(storeedShop);
+    const storedShop = localStorage.getItem('registeredShop');
+    if (storedShop) {
+      const paredShop: ShopDetail = JSON.parse(storedShop);
       setShopId(paredShop.id);
+    }
+  }, []);
+
+  // (추후 로직 변경) 로그아웃하면서 로컬스토리지가 사라질 경우 유저의 id를 반영해서 shop정보 가져오기
+  // useEffect(() => {
+  //   const storedShop = localStorage.getItem('registeredShop');
+  //   const shopFromAuthData = localStorage.getItem('auth-data');
+  //   if (storedShop) {
+  //     const paredShop: ShopDetail = JSON.parse(storedShop);
+  //     setShopId(paredShop.id);
+  //   } else {
+  //     // 로그아웃하면서 로컬스토리지가 사라질 경우 유저의 id를 반영해서 shop정보 가져오기
+  //     const authData = JSON.parse(shopFromAuthData);
+  //     const shopDetails = authData?.state?.userData?.item?.user?.item?.shop?.item?.id;
+  //     setShopId(shopDetails);
+  //   }
+  // }, []);
+
+  useEffect(() => {
+    const shopFromAuthData = localStorage.getItem('auth-data');
+    if (shopFromAuthData) {
+      // 로그아웃하면서 로컬스토리지가 사라질 경우 유저의 id를 반영해서 shop정보 가져오기
+      const authData = JSON.parse(shopFromAuthData);
+      const shopDetails = authData?.state?.userData?.item?.user?.item?.shop?.item?.id;
+      setShopId(shopDetails);
+    } else {
+      console.error();
     }
   }, []);
 

--- a/src/app/owner/register-job/page.tsx
+++ b/src/app/owner/register-job/page.tsx
@@ -105,13 +105,13 @@ export default function JobPostFormPage() {
     // 등록 모드: URL에 noticeId가 없을 때
     else {
       setIsEditMode(false);
-      const storedShop = localStorage.getItem('registeredShop');
-      if (storedShop) {
-        const parsedShop = JSON.parse(storedShop);
-        setShopId(parsedShop.id);
+      const shopFromAuthData = localStorage.getItem('auth-data');
+      if (shopFromAuthData) {
+        const authData = JSON.parse(shopFromAuthData);
+        const shopDetails = authData?.state?.userData?.item?.user?.item?.shop?.item?.id;
+        setShopId(shopDetails);
       } else {
-        alert('가게 정보가 없습니다. 가게를 먼저 등록해주세요.');
-        router.push('/owner');
+        console.error('에러 발생');
       }
       setFormLoading(false);
     }

--- a/src/app/owner/register-store/page.tsx
+++ b/src/app/owner/register-store/page.tsx
@@ -265,7 +265,7 @@ export default function Page() {
   };
 
   const handleClose = () => {
-    router.push('/owner'); // 소유주 메인 페이지로 이동
+    router.push('/owner/owner-store-detail'); // 소유주 메인 페이지로 이동
   };
 
   const handleSelect = (key: keyof typeof form, value: string) => {

--- a/src/components/common/Header/UserMenu.tsx
+++ b/src/components/common/Header/UserMenu.tsx
@@ -19,7 +19,7 @@ const UserMenu = () => {
   const router = useRouter();
   const token = useToken();
   const albaActiveLink = userData?.item.user.item.name ? '/member/myprofile' : '/member/profile';
-  const ownerActiveLink = userData?.item.user.item.name ? '/owner/owner-store-detail' : '/owner';
+  const ownerActiveLink = userData?.item.user.item.shop ? '/owner/owner-store-detail' : '/owner';
 
   const userValue = useMemo(() => {
     if (!userData) return null;

--- a/src/lib/hooks/use-auth.tsx
+++ b/src/lib/hooks/use-auth.tsx
@@ -17,7 +17,10 @@ const useAuth = create<AuthState>()(
       userData: null,
       isInitialized: false,
       login: (userData: LoginResponse) => set({ userData, isInitialized: true }),
-      logout: () => set({ userData: null }),
+      logout: () => {
+        localStorage.removeItem('registeredShop');
+        set({ userData: null });
+      },
       updateUserData: (newUserData: Partial<UserItem>) =>
         set((state) => {
           if (!state.userData) return {};


### PR DESCRIPTION
## #️⃣연관된 이슈

> PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

- close: #81 

## 🪄작업 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

<img width="714" alt="Screenshot 2025-06-20 at 8 17 19 pm" src="https://github.com/user-attachments/assets/30bb78b7-6315-472f-b77c-26dc3199b224" />

-  마감,지난 공고 UI 처리하였습니다.
- 기존 로컬스토리지(registeredShop)에서 shop 정보 불러오던 것을 auth-data에서 불러오는것으로 수정하였습니다.

## 💖리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

- 속도가 느려서 다시 수정할수도 있겠네요..
- 가게 등록 후 새로고침해야 가게 정보가 불러와집니다.
